### PR TITLE
fix: Add discountType to addState function signature

### DIFF
--- a/src/stores/useCounterStore.js
+++ b/src/stores/useCounterStore.js
@@ -76,7 +76,7 @@ export const useCounterStore = defineStore('counter', () => {
 
   // --- Estados ---
 
-  function addState({ name, shortRest, longRest, linkedCounterId, discountOnActivate }) {
+  function addState({ name, shortRest, longRest, linkedCounterId, discountOnActivate, discountType }) {
     states.value.push({
       id: nanoid(),
       name,


### PR DESCRIPTION
This commit fixes a ReferenceError that occurred when creating a new state. The `addState` function in `useCounterStore.js` was trying to access the `discountType` variable without having it defined in its function signature. This change adds `discountType` to the function's destructured parameters, resolving the error.